### PR TITLE
Specify minimum JVM version in the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,11 @@
 
 An extraction of our main app at Cognician.
 
+## Minimum Requirements
+
+A JDK supporting the [Java Platform Module System][illegal-access-faq] (>= JDK 9).
+If your distro's default JDK is version 8 or older, you will need to [upgrade][migrate-to-jdk-11] before building this app.
+
 ## Usage
 
 Clone this repo, run the commands explained below to see it in action, and then use it as a reference to create (or alter) your own app.
@@ -71,3 +76,8 @@ Clojurians Slack: No specific one, but `#emacs` will probably help!
 <https://shadow-cljs.github.io/docs/UsersGuide.html>
 
 Clojurians Slack: `#shadow-cljs`
+
+
+<!-- JDK help topics -->
+[illegal-access-faq]: https://clojure.org/guides/faq#illegal_access
+[migrate-to-jdk-11]: https://www.deps.co/blog/how-to-upgrade-clojure-projects-to-use-java-11


### PR DESCRIPTION
JVMs older than 1.9 will fail to interpret the `--illegal-access` option passed in by the [`jvm-opts` vector](https://github.com/robert-stuttaford/clj-cljs-app/blob/master/deps.edn#L9).

Making this explicit will prevent build failures like this one:
```
$ java -version
openjdk version "1.8.0_265"
OpenJDK Runtime Environment (build 1.8.0_265-8u265-b01-0+deb9u1-b01)
OpenJDK 64-Bit Server VM (build 25.265-b01, mixed mode)

$ make dev
clojure -A:cljs:dev clj-run build/run
. . . .
Unrecognized option: --illegal-access=deny
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Makefile:9: recipe for target 'dev' failed
make: *** [dev] Error 1
```
